### PR TITLE
Support reimporting the transport document

### DIFF
--- a/ec-persistence/src/main/java/org/dcsa/endorsementchain/persistence/entity/TransportDocument.java
+++ b/ec-persistence/src/main/java/org/dcsa/endorsementchain/persistence/entity/TransportDocument.java
@@ -1,6 +1,7 @@
 package org.dcsa.endorsementchain.persistence.entity;
 
 import lombok.*;
+import org.dcsa.skernel.errors.exceptions.ConcreteRequestErrorMessageException;
 
 import javax.persistence.*;
 import java.util.Set;
@@ -39,4 +40,10 @@ public class TransportDocument {
     return this;
   }
 
+  public void reimported() {
+    if (!this.getIsExported()) {
+      throw ConcreteRequestErrorMessageException.conflict("Document is already imported!?", null);
+    }
+    this.isExported = Boolean.TRUE;
+  }
 }


### PR DESCRIPTION
This flow happens in practice for the carrier, where they start by
exporting the document and then import later (when the document is
surrendered).

It could probably also happen for other platforms that the document
returns to the platform (but a different user).
